### PR TITLE
Adiciona ano de lançamento nas reviews

### DIFF
--- a/app/Http/Controllers/Private/ReviewController.php
+++ b/app/Http/Controllers/Private/ReviewController.php
@@ -63,6 +63,7 @@ class ReviewController extends Controller
         $review = Review::create([
             'title' => $request->input('title'),
             'sinopse' => $request->input('sinopse'),
+            'year_of_release' => $request->input('year_of_release'),
             'image' => $this->image->store('reviews', $request->file('image'), 'public'),
             'cover' => $this->image->store('reviews', $request->file('cover'), 'public'),
         ]);
@@ -82,6 +83,7 @@ class ReviewController extends Controller
         $review->fill([
             'title' => $request->input('title'),
             'sinopse' => $request->input('sinopse'),
+            'year_of_release' => $request->input('year_of_release'),
             'image' => $this->image->store('reviews', $request->file('image'), 'public', $review->image),
             'cover' => $this->image->store('reviews', $request->file('cover'), 'public', $review->cover),
         ]);

--- a/app/Http/Resources/ReviewResource.php
+++ b/app/Http/Resources/ReviewResource.php
@@ -15,6 +15,7 @@ class ReviewResource extends JsonResource
             'cover' => $this->cover,
             'image' => $this->image,
             'title' => $this->title,
+            'year_of_release' => $this->year_of_release,
             'sinopse' => $this->sinopse,
             'views' => $this->views_count,
             'reviews' => $this->reviews->map(fn($item) => [

--- a/database/factories/ReviewFactory.php
+++ b/database/factories/ReviewFactory.php
@@ -21,6 +21,7 @@ class ReviewFactory extends Factory
             'cover' => 'https://placehold.co/500x500?text=Rede%20Akiba%20Placeholder',
             'image' => 'https://placehold.co/500x500?text=Rede%20Akiba%20Placeholder',
             'title' => fake()->word(),
+            'year_of_release' => fake()->year(),
             'sinopse' => fake()->paragraph(),
         ];
     }

--- a/database/migrations/2026_04_27_004524_add_column_year_of_release_to_reviews_table.php
+++ b/database/migrations/2026_04_27_004524_add_column_year_of_release_to_reviews_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->integer('year_of_release')->nullable()->after('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropColumn('year_of_release');
+        });
+    }
+};

--- a/resources/js/ui/widgets/private/form/ReviewForm.svelte
+++ b/resources/js/ui/widgets/private/form/ReviewForm.svelte
@@ -16,6 +16,7 @@
         title: null,
         sinopse: null,
         cover: null,
+        year_of_release: null,
         review: { uuid: null, content: null },
     });
 
@@ -25,6 +26,7 @@
         $form.title = review.data.title;
         $form.sinopse = review.data.sinopse;
         $form.cover = review.data.cover;
+        $form.year_of_release = review.data.year_of_release;
         $form.review = { uuid: null, content: "" };
     }
 
@@ -123,6 +125,19 @@
                     />
                 </div>
                 <div class="mb-8">
+                    <label for="year_of_release" class="text-orange-amber font-bold italic text-lg uppercase font-noto-sans block mb-2">
+                        Ano de lançamento
+                    </label>
+                    <input
+                        id="year_of_release"
+                        type="number"
+                        name="year_of_release"
+                        class="w-full h-12 bg-suspense-aurora font-noto-sans rounded-lg outline-none pl-4"
+                        bind:value={$form.year_of_release}
+                        required
+                    />
+                </div>
+                <div class="mb-8">
                     <label for="sinopse" class="text-orange-amber font-bold italic text-lg uppercase font-noto-sans block mb-2">
                         Sinopse do anime
                     </label>
@@ -178,7 +193,6 @@
         <div class="flex flex-wrap gap-4 justify-center lg:flex-nowrap mt-10">
             {#if can.create || can.update}
                 <button
-                    aria-label=""
                     type="submit"
                     class="cursor-pointer w-full lg:w-auto py-2 px-6 border-4 border-solid border-blue-skywave rounded-xl text-blue-skywave text-xl font-bold font-noto-sans italic uppercase"
                 >


### PR DESCRIPTION
## Objetivo

Adicionar o campo de ano de lançamento ao cadastro e edição de reviews.

Closes #17
Related to #30

## O Que Mudou?

- [x] Adicionado campo `year_of_release` na tabela `reviews` via migration
- [x] Persistido o ano de lançamento ao criar e atualizar reviews
- [x] Exibido e preenchido o campo no formulário privado de reviews

## Como Testar

1. Executar as migrations do projeto
2. Criar uma nova review preenchendo o campo "Ano de lançamento"
3. Editar uma review existente e confirmar que o ano é carregado e salvo corretamente

## Tipo de Alteração

- [ ] Correção de bug
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [ ] Performance
- [ ] Segurança

## Checklist

- [x] Meu código segue os padrões do projeto
- [ ] Rodei o lint e não há erros
- [ ] Adicionei testes, se aplicável
- [ ] Os testes passam localmente
- [ ] Atualizei a documentação, se necessário
- [ ] Testei em navegadores diferentes, se isso afeta o frontend
- [x] Não há conflitos de merge
- [x] As alterações não quebram funcionalidades existentes

## Screenshots

Não se aplica.

## Links Relacionados

- Relacionado a #17
- Relacionado a #30

## Notas Adicionais

Validação automatizada não foi executada localmente antes da abertura deste PR.