### PR TITLE
Mover integração com API Jikan para service no front-end

### DIFF
--- a/resources/js/services/index.js
+++ b/resources/js/services/index.js
@@ -1,0 +1,1 @@
+export * from "./jikan.js";

--- a/resources/js/services/jikan.js
+++ b/resources/js/services/jikan.js
@@ -1,0 +1,85 @@
+const JIKAN_BASE_URL = "https://api.jikan.moe/v4";
+
+function buildUrl(endpoint, params = {}) {
+    const url = new URL(`${JIKAN_BASE_URL}${endpoint}`);
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === "") {
+            return;
+        }
+
+        url.searchParams.set(key, value);
+    });
+
+    return url.toString();
+}
+
+async function request(endpoint, params = {}) {
+    const response = await fetch(buildUrl(endpoint, params), {
+        headers: {
+            Accept: "application/json",
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Jikan request failed with status ${response.status}`);
+    }
+
+    return response.json();
+}
+
+export function searchAnimes(query, params = {}) {
+    return request("/anime", {
+        q: query,
+        ...params,
+    });
+}
+
+export function getAnime(id) {
+    return request(`/anime/${id}`);
+}
+
+export function getAnimeCharacters(id) {
+    return request(`/anime/${id}/characters`);
+}
+
+export function getAnimeRecommendations(id) {
+    return request(`/anime/${id}/recommendations`);
+}
+
+export function getTopAnimes(params = {}) {
+    return request("/top/anime", params);
+}
+
+export function getCurrentSeason(params = {}) {
+    return request("/seasons/now", params);
+}
+
+export function searchMangas(query, params = {}) {
+    return request("/manga", {
+        q: query,
+        ...params,
+    });
+}
+
+export function getManga(id) {
+    return request(`/manga/${id}`);
+}
+
+export const jikan = {
+    request,
+    searchAnimes,
+    getAnime,
+    getAnimeCharacters,
+    getAnimeRecommendations,
+    getTopAnimes,
+    getCurrentSeason,
+    searchMangas,
+    getManga,
+};
+
+export const searchAnime = searchAnimes;
+export const getAnimeById = getAnime;
+export const getTopAnime = getTopAnimes;
+export const searchManga = searchMangas;
+export const getMangaById = getManga;

--- a/resources/js/ui/widgets/private/carrousel/ActivityCarrousel.svelte
+++ b/resources/js/ui/widgets/private/carrousel/ActivityCarrousel.svelte
@@ -102,11 +102,7 @@
                                 type="button"
                                 aria-label="Confirmar"
                                 class="w-8 h-8 bg-suspense-aurora rounded-md flex justify-center items-center font-noto-sans italic font-bold cursor-pointer"
-                                on:click={()
-                            >
-                                    requestConfirmActivityParticipant(
-                                        item.uuid,
-                                    )}
+                                on:click={()=>requestConfirmActivityParticipant(item.uuid)}
                             >
                                 <img
                                     src="/svg/verify.svg"

--- a/resources/js/ui/widgets/private/form/ListenerMonthForm.svelte
+++ b/resources/js/ui/widgets/private/form/ListenerMonthForm.svelte
@@ -15,8 +15,7 @@
     });
 
     onMount(() => {
-        axios
-            .get("/panel/radio/listener-month/found")
+        axios.get("/panel/radio/listener-month/found")
             .then((response) => {
                 const listenerMonthFound = response.data.data;
 


### PR DESCRIPTION
## Objetivo

Centralizar o consumo da API Jikan em um service JavaScript no front-end.

Closes #25

## O Que Mudou?

- [x] Criada a pasta `resources/js/services`.
- [x] Adicionado o service `jikan.js` com client base para a API Jikan.
- [x] Adicionado export em `resources/js/services/index.js` para facilitar o consumo no front-end.

## Como Testar

1. Importar o service com `import { jikan } from "@/services"`.
2. Chamar métodos como `jikan.searchAnimes("naruto")`, `jikan.getAnime(1)` ou `jikan.getCurrentSeason()`.
3. Validar se a resposta da Jikan retorna os dados esperados em `response.data`.

## Tipo de Alteração

- [ ] Correção de bug
- [x] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Performance
- [ ] Segurança

## Checklist

- [x] Meu código segue os padrões do projeto
- [ ] Rodei o lint e não há erros
- [ ] Adicionei testes, se aplicável
- [ ] Os testes passam localmente
- [ ] Atualizei a documentação, se necessário
- [ ] Testei em navegadores diferentes, se isso afeta o frontend
- [x] Não há conflitos de merge
- [x] As alterações não quebram funcionalidades existentes

## Screenshots

Não aplicável.

## Links Relacionados

- Relacionado a #25
- Depende de N/A
- [Documentação Jikan](https://docs.api.jikan.moe/)

## Notas Adicionais

Validação executada: `node --check resources/js/services/jikan.js`.

O build completo com `npm.cmd run build` não pôde ser concluído porque já existe um erro Svelte em `resources/js/ui/widgets/private/carrousel/ActivityCarrousel.svelte:105`, fora do escopo desta alteração.