### PR TITLE
Move SVGs inline para arquivos públicos

### DIFF
--- a/public/svg/chevron-down.svg
+++ b/public/svg/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#9ca3af" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+    <polyline points="6 9 12 15 18 9"/>
+</svg>

--- a/public/svg/menu.svg
+++ b/public/svg/menu.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="2" viewBox="0 0 24 24">
+    <path d="M4 6h16M4 12h16M4 18h16" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/svg/x.svg
+++ b/public/svg/x.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="2" viewBox="0 0 24 24">
+    <path d="M6 18L18 6M6 6l12 12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/js/ui/widgets/private/navbar/Navbar.svelte
+++ b/resources/js/ui/widgets/private/navbar/Navbar.svelte
@@ -43,20 +43,12 @@
 <!-- Mobile Navbar -->
 <nav class="w-full h-16 bg-suspense-aurora flex items-center justify-between px-10 lg:hidden">
     <button aria-label="Abrir menu" on:click={() => (mobilenavbar = !mobilenavbar)}>
-        <svg
+        <img
+            src="/svg/menu.svg"
+            alt=""
             class="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
             aria-hidden="true"
-        >
-            <path
-                d="M4 6h16M4 12h16M4 18h16"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-            />
-        </svg>
+        />
     </button>
     <img
         src={user.avatar}
@@ -79,20 +71,12 @@
             loading="lazy"
         />
         <button aria-label="Fechar menu" on:click={() => (mobilenavbar = false)}>
-            <svg
+            <img
+                src="/svg/x.svg"
+                alt=""
                 class="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
                 aria-hidden="true"
-            >
-                <path
-                    d="M6 18L18 6M6 6l12 12"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                />
-            </svg>
+            />
         </button>
     </div>
     <ul class="p-5 pt-3 space-y-4">

--- a/resources/js/ui/widgets/public/form/SongRequestForm.svelte
+++ b/resources/js/ui/widgets/public/form/SongRequestForm.svelte
@@ -214,18 +214,12 @@
                             </span>
                         </div>
                     {/if}
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
+                    <img
+                        src="/svg/chevron-down.svg"
+                        alt=""
                         class="w-5 h-5 text-gray-400 shrink-0 ml-2"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                    >
-                        <polyline points="6 9 12 15 18 9"></polyline>
-                    </svg>
+                        aria-hidden="true"
+                    />
                 </button>
                 {#if activeMusicDropdown && animeThemesList.length > 0}
                     <div class="absolute w-full mt-2 bg-white border border-gray-100 rounded-2xl shadow-2xl z-30 max-h-56 overflow-y-auto">

--- a/resources/js/ui/widgets/public/navbar/Navbar.svelte
+++ b/resources/js/ui/widgets/public/navbar/Navbar.svelte
@@ -13,20 +13,12 @@
             class="xl:hidden p-1 filter invert"
             on:click={() => (mobilenavbar = !mobilenavbar)}
         >
-            <svg
+            <img
+                src="/svg/menu.svg"
+                alt=""
                 class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
                 aria-hidden="true"
-            >
-                <path
-                    d="M4 6h16M4 12h16M4 18h16"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                />
-            </svg>
+            />
         </button>
 
         <div class="ml-5">
@@ -127,19 +119,12 @@
                     class="text-blue-night"
                     on:click={() => (mobilenavbar = false)}
                 >
-                    <svg
+                    <img
+                        src="/svg/x.svg"
+                        alt=""
                         class="w-6 h-6"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                    >
-                        <path
-                            d="M6 18L18 6M6 6l12 12"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                        />
-                    </svg>
+                        aria-hidden="true"
+                    />
                 </button>
             </div>
 


### PR DESCRIPTION
## Resumo

Move os SVGs inline encontrados nos componentes Svelte para arquivos externos em `public/svg`, mantendo os componentes apontando para os assets via `<img>`.

Closes #13

Base: develop

Development: #13

Labels: front-end, enhancement

## Como testar

- [x] `rg -n -i "<\\s*svg" --glob "*.svelte"`
- [ ] `npm.cmd run build` não concluiu por erro já existente em `resources/js/ui/widgets/private/carrousel/ActivityCarrousel.svelte:105:43`

## Checklist

- [x] Testei as alteracoes principais
- [ ] Atualizei documentacao, se necessario