### PR TITLE
[codex] centraliza review fantasma no back-end

### DIFF
--- a/app/Http/Resources/ReviewResource.php
+++ b/app/Http/Resources/ReviewResource.php
@@ -18,7 +18,41 @@ class ReviewResource extends JsonResource
             'year_of_release' => $this->year_of_release,
             'sinopse' => $this->sinopse,
             'views' => $this->views_count,
-            'reviews' => ReviewContentResource::collection($this->reviews),
+            'reviews' => $this->reviewsCurrentWithUser($request),
+        ];
+    }
+
+    private function reviewsCurrentWithUser(Request $request): array
+    {
+        $user = $request->user();
+        $reviews = ReviewContentResource::collection($this->reviews)->resolve();
+
+        $currentUserReview = collect($reviews)->first(
+            fn ($review) => $review['author']['uuid'] === $user->uuid
+        );
+
+        if ($currentUserReview) {
+            return [
+                $currentUserReview,
+                ...collect($reviews)
+                    ->reject(fn ($review) => $review['author']['uuid'] === $user->uuid)
+                    ->values()
+                    ->all(),
+            ];
+        }
+
+        return [
+            [
+                'uuid' => null,
+                'content' => 'Escreva o seu primeiro review',
+                'author' => [
+                    'uuid' => $user->uuid,
+                    'name' => $user->name,
+                    'nickname' => $user->nickname,
+                    'avatar' => $user->avatar,
+                ],
+            ],
+            ...$reviews,
         ];
     }
 }


### PR DESCRIPTION
## Resumo

Move a preparação da lista de reviews para o `ReviewResource`, fazendo o back-end retornar a review do usuário logado primeiro ou um review fantasma quando ele ainda não tiver publicado.

Closes #27

## Como testar

- [x] Rodar `php -l app\\Http\\Resources\\ReviewResource.php`

## Checklist

- [x] Testei as alteracoes principais
- [x] Atualizei documentacao, se necessario