### PR TITLE
[codex] usa resource para activity do calendário

### DIFF
--- a/app/Http/Resources/CalendarResource.php
+++ b/app/Http/Resources/CalendarResource.php
@@ -21,10 +21,7 @@ class CalendarResource extends JsonResource
             'type' => $this->type,
             'day_of_week' => $this->day_of_week,
             'responsible' => UserResource::make($this->responsible),
-            'activity' => $this->has_activity ? [
-                'uuid' => $this->activity->uuid,
-                'title' => $this->activity->title,
-            ] : null,
+            'activity' => $this->has_activity ? ActivityResource::make($this->activity) : null,
         ];
     }
 }


### PR DESCRIPTION
## Resumo

Atualiza o `CalendarResource` para representar a atividade vinculada usando `ActivityResource`, evitando montar manualmente os dados da activity dentro do resource do calendário.

Closes #39

## Como testar

- [x] Rodar `php -l app\\Http\\Resources\\CalendarResource.php`

## Checklist

- [x] Testei as alteracoes principais
- [x] Atualizei documentacao, se necessario